### PR TITLE
Fix memset call to proper size

### DIFF
--- a/motoman_driver/MotoPlus/CtrlGroup.c
+++ b/motoman_driver/MotoPlus/CtrlGroup.c
@@ -454,7 +454,7 @@ BOOL Ros_CtrlGroup_GetTorque(CtrlGroup* ctrlGroup, double torqueValues[MAX_PULSE
   	LONG status = 0;
   	int i;
 
-	memset(torqueValues, 0, sizeof(torqueValues)); // clear result, in case of error
+	memset(torqueValues, 0, sizeof(double [MAX_PULSE_AXES])); // clear result, in case of error
 	memset(dst_trq.data, 0, sizeof(MP_TRQCTL_DATA));
 	dst_trq.unit = TRQ_NEWTON_METER; //request data in Nm
 


### PR DESCRIPTION
`sizeof(torqueValues)` is 4 (because `double torqueValues[MAX_PULSE_AXES]` as a parameter in C is equivalent to `double *torqueValues`, so the size of the pointer), while we actually want to clear the data behind the pointer. Modern compilers warn:

> Sizeof on array function parameter will return size of `double *` instead of `double [8]` (-Wsizeof-array-argument)

This does prompt a question on whether this call should exist at all, because no problems occurred when it was incorrectly setting data. Just to be safe, I'm leaving it in.

Incidentally, this function is never called, and can probably be removed entirely.